### PR TITLE
Don't pass events that have no jets

### DIFF
--- a/calratio_training_data/training_query.py
+++ b/calratio_training_data/training_query.py
@@ -88,7 +88,9 @@ def build_preselection():
 
     # Preselection
     query_preselection = query_base_objects.Where(
-        lambda e: len(e.vertices) > 0 and e.vertices.First().nTrackParticles() > 0  # type: ignore
+        lambda e: len(e.vertices) > 0  # type: ignore
+        and e.vertices.First().nTrackParticles() > 0
+        and len(e.jets) > 0  # type: ignore
     )
 
     return query_preselection


### PR DESCRIPTION
* Require `n_good_jet>0`

Otherwise why train? ;-)

Fixes #18