### PR TITLE
Check fixed xAOD generation bug

### DIFF
--- a/calratio_training_data/cpp_xaod_utils.py
+++ b/calratio_training_data/cpp_xaod_utils.py
@@ -87,12 +87,12 @@ def cvt_to_raw_calocluster_callback(
             "metadata_type": "add_cpp_function",
             "name": "cvt_to_raw_calocluster",
             "code": [
-                "// Very ugly!\n",
-                "const xAOD::CaloCluster* clus = dynamic_cast<const xAOD::CaloCluster*>(*link);\n",
+                "// Very ugly",
+                "const xAOD::CaloCluster* clus = dynamic_cast<const xAOD::CaloCluster*>(*link)",
                 "const SG::AuxElement::ConstAccessor< ElementLink<xAOD::IParticleContainer> > "
-                'originalObject("originalObjectLink");\n',
+                'originalObject("originalObjectLink")',
                 "const xAOD::CaloCluster* result = dynamic_cast<const xAOD::CaloCluster*> "
-                "(*originalObject(*clus));\n",
+                "(*originalObject(*clus))",
             ],
             "result": "result",
             "include_files": ["xAODCaloEvent/CaloCluster.h"],
@@ -168,7 +168,7 @@ def jet_clean_llp_callback(
         {
             "metadata_type": "add_cpp_function",
             "name": "jet_clean_llp",
-            "code": ["bool result = m_jetCleaning_llp->keep(*jet);\n"],
+            "code": ["bool result = m_jetCleaning_llp->keep(*jet)"],
             "result": "result",
             "include_files": [],
             "arguments": ["jet"],

--- a/calratio_training_data/fetch.py
+++ b/calratio_training_data/fetch.py
@@ -35,7 +35,7 @@ def main(
     ),
     ignore_cache: bool = typer.Option(
         False,
-        "--ignore_cache",
+        "--ignore-cache",
         help="Ignore cache and fetch fresh data",
     ),
     local: bool = typer.Option(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["black", "typer", "servicex-cli", "pytest", "pytest-mock"]
+dev = ["black", "typer", "pytest", "pytest-mock"]
 notebook = ["jupyterlab", "ipywidgets", "hist", "mplhep", "scipy", "pandas"]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "ServiceX-Local",
     "servicex",
     "func_adl_servicex_xaodr25",
-    "servicex-cli",
     "servicex-analysis-utils",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "dask_awkward",
     "uproot",
     "func_adl_xAOD",
-    "func_adl==3.4.0b6",
+    "func_adl",
     "ServiceX-Local",
     "servicex",
     "func_adl_servicex_xaodr25",


### PR DESCRIPTION
* Checking new version of func_adl_xAOD that fixes the [placement of the `if` statement](https://github.com/iris-hep/func_adl_xAOD/issues/255).
* Unpin the `func_adl` version
* Change command line option`ignore_cache` to `ignore-cache`
* Remove `servicex-cli` from package dependency lists - that is only for secrets, that is not the client command line.
* Clean up some C++ code formatting (too many \n's!).

Fixes #50