### PR TITLE
Add python minimum for a package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "func_adl_servicex_xaodr25",
     "servicex-analysis-utils",
 ]
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 dev = ["black", "typer", "pytest", "pytest-mock"]


### PR DESCRIPTION
* The package needs at least 3.10 to work correctly.

Fixes #61