### PR TITLE
Return to better compression

### DIFF
--- a/calratio_training_data/training_query.py
+++ b/calratio_training_data/training_query.py
@@ -490,7 +490,7 @@ def fetch_training_data_to_file(ds_name: str, config: RunConfig):
 
     # Finally, write it out into a training file.
     ak.to_parquet(
-        result_list, config.output_path, compression="ZSTD", compression_level=20
+        result_list, config.output_path, compression="ZSTD", compression_level=-7
     )
 
 

--- a/calratio_training_data/training_query.py
+++ b/calratio_training_data/training_query.py
@@ -490,7 +490,7 @@ def fetch_training_data_to_file(ds_name: str, config: RunConfig):
 
     # Finally, write it out into a training file.
     ak.to_parquet(
-        result_list, config.output_path, compression="GZIP", compression_level=9
+        result_list, config.output_path, compression="ZSTD", compression_level=20
     )
 
 


### PR DESCRIPTION
* Move to zstd, with compression level 22, which is the most and slowest.
* zstd read time is about the same no matter the compression level.

Fixes #67