### PR TITLE
Add sx-backend flag

### DIFF
--- a/calratio_training_data/fetch.py
+++ b/calratio_training_data/fetch.py
@@ -41,23 +41,23 @@ def main(
     local: bool = typer.Option(
         False,
         "--local",
-        help="Run ServiceX locally, fail if not possible (requires docker)",
+        help="Run ServiceX locally (requires docker)",
     ),
     output: str = typer.Option(
         "training.parquet",
         "--output",
         "-o",
-        help="Output file path (default: training.parquet)",
+        help="Output file path",
     ),
     mc: bool = typer.Option(
         False,
         "--mc",
-        help="Include LLP MC truth info (default: False)",
+        help="Include LLP MC truth info",
     ),
     sx_backend: str = typer.Option(
         "servicex",
         "--sx-backend",
-        help="ServiceX backend name (default: servicex)",
+        help="ServiceX backend name",
     ),
 ):
     """

--- a/calratio_training_data/fetch.py
+++ b/calratio_training_data/fetch.py
@@ -54,6 +54,11 @@ def main(
         "--mc",
         help="Include LLP MC truth info (default: False)",
     ),
+    sx_backend: str = typer.Option(
+        "servicex",
+        "--sx-backend",
+        help="ServiceX backend name (default: servicex)",
+    ),
 ):
     """
     Fetch training data for cal ratio.
@@ -65,7 +70,11 @@ def main(
     )
 
     run_config = RunConfig(
-        ignore_cache=ignore_cache, run_locally=local, output_path=output, mc=mc
+        ignore_cache=ignore_cache,
+        run_locally=local,
+        output_path=output,
+        mc=mc,
+        sx_backend=sx_backend,
     )
     fetch_training_data_to_file(dataset, run_config)
 

--- a/calratio_training_data/sx_utils.py
+++ b/calratio_training_data/sx_utils.py
@@ -17,7 +17,9 @@ class SXLocationOptions(Enum):
     anyLocation = "anyLocation"
 
 
-def build_sx_spec(query, ds_name: str, prefer_local: bool = False):
+def build_sx_spec(
+    query, ds_name: str, prefer_local: bool = False, backend_name: str = "servicex"
+):
     """Build a ServiceX spec from the given query and dataset."""
 
     # Pass our local preference to find_dataset.
@@ -34,9 +36,10 @@ def build_sx_spec(query, ds_name: str, prefer_local: bool = False):
     adaptor = None
     # Second branch: decide on the backend.
     if use_local:
-        codegen_name, backend_name, adaptor = install_sx_local()
+        codegen_name, backend_name_local, adaptor = install_sx_local()
+        backend = backend_name_local
     else:
-        backend_name = "af.uchicago"
+        backend = backend_name
         codegen_name = "atlasr25"
 
     # Build the ServiceX spec
@@ -51,7 +54,7 @@ def build_sx_spec(query, ds_name: str, prefer_local: bool = False):
         ],
     )
 
-    return spec, backend_name, adaptor
+    return spec, backend, adaptor
 
 
 def find_dataset(

--- a/calratio_training_data/training_query.py
+++ b/calratio_training_data/training_query.py
@@ -51,6 +51,7 @@ class RunConfig:
     run_locally: bool
     output_path: str = "training.parquet"
     mc: bool = False
+    sx_backend: str = "af.uchicago"
 
 
 @dataclass
@@ -541,7 +542,11 @@ def run_query(
     config: RunConfig = RunConfig(ignore_cache=False, run_locally=False),
 ) -> Dict[str, ak.Array]:
     # Build the ServiceX spec and run it.
-    spec, backend_name, adaptor = build_sx_spec(query, ds_name, config.run_locally)
+    from .sx_utils import build_sx_spec
+
+    spec, backend_name, adaptor = build_sx_spec(
+        query, ds_name, config.run_locally, config.sx_backend
+    )
     if config.run_locally or backend_name == "local-backend":
         sx_result = sx_local.deliver(
             spec, adaptor=adaptor, ignore_local_cache=config.ignore_cache

--- a/calratio_training_data/training_query.py
+++ b/calratio_training_data/training_query.py
@@ -39,7 +39,6 @@ from .cpp_xaod_utils import (
     jet_clean_llp,
     track_summary_value,
 )
-from .sx_utils import build_sx_spec
 
 vector.register_awkward()
 


### PR DESCRIPTION
* Add `--sx-backend` flag to indicate a different servicex backnd to run on.
* Defaults to `servicex` which is usually `af.uchciago`.
* Clean up some random comments, and help strings.

Working on #84