### PR TITLE
Fix grammar in docstring

### DIFF
--- a/calratio_training_data/sx_utils.py
+++ b/calratio_training_data/sx_utils.py
@@ -66,7 +66,7 @@ def find_dataset(
 
     Args:
         ds_name (str): The name of the dataset to be fetched.
-        prefer_local (boo): If we can construct the url in a way that will let us
+        prefer_local (bool): If we can construct the url in a way that will let us
             run locally, then do it. The returned location options must still
             be checked, however. And even if this can't run locally (e.g. rucio
             dataset), no error will be produced.

--- a/calratio_training_data/training_query.py
+++ b/calratio_training_data/training_query.py
@@ -76,7 +76,7 @@ class TopLevelEvent:
 
 
 def good_training_jet(jet: Jet_v1) -> bool:
-    """Check the the jet is good as a training"""
+    """Check that the jet is suitable for training"""
     return jet.pt() / 1000.0 > 40.0 and abs(jet.eta()) < 2.5 and jet_clean_llp(jet)
 
 


### PR DESCRIPTION
## Summary
- fix grammar in `good_training_jet` docstring

## Testing
- `pytest -q` *(fails: servicex backend expected af.uchicago)*

------
https://chatgpt.com/codex/tasks/task_e_68693e34c608832091be2e1b6a8f586d