### PR TITLE
Minor: Fix return type for track summary

### DIFF
--- a/calratio_training_data/cpp_xaod_utils.py
+++ b/calratio_training_data/cpp_xaod_utils.py
@@ -43,7 +43,7 @@ def track_summary_value_callback(
             "result": "result",
             "include_files": [],
             "arguments": ["trk", "value_selector"],
-            "return_type": "float",
+            "return_type": "int",
         }
     )
     new_s = add_enum_info(new_s, "SummaryType")

--- a/calratio_training_data/sx_utils.py
+++ b/calratio_training_data/sx_utils.py
@@ -18,7 +18,7 @@ class SXLocationOptions(Enum):
 
 
 def build_sx_spec(
-    query, ds_name: str, prefer_local: bool = False, backend_name: str = "servicex"
+    query, ds_name: str, prefer_local: bool = False, backend_name: str = "af.uchicago"
 ):
     """Build a ServiceX spec from the given query and dataset."""
 


### PR DESCRIPTION
## Summary
- ensure `track_summary_value` returns an int from C++
- restore default ServiceX backend to `af.uchicago`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68693e3c2fec8320bb181b91a83b5bea