### PR TITLE
Enhance file handling and logging improvements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "console": "integratedTerminal",
             "args": [
                 // "--ignore_cache",
-                "DAOD_LLP1.outputLLP1_mc23_527565_LeadingJets_08042025.pool.root",
+                "mc23_13p6TeV:mc23_13p6TeV.802594.Py8EG_EmergingJ_ModelD_1500_5.deriv.DAOD_LLP1.e8531_e8586_s4159_s4114_r15530_r15514_p6463",
                 "--mc",
             ]
         }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,6 +39,7 @@
     "msegs",
     "muonsegment",
     "mypy",
+    "nbytes",
     "NNPDF",
     "nosetests",
     "origclus",

--- a/calratio_training_data/fetch.py
+++ b/calratio_training_data/fetch.py
@@ -16,7 +16,7 @@ def set_logging(verbosity: int):
         if verbosity == 0
         else logging.INFO if verbosity == 1 else logging.DEBUG
     )
-    logging.basicConfig(level=level)
+    logging.basicConfig(level=level, force=True)
 
     # This isn't normally set. However, some of our functions need to grab everything, so
     # they may mess with the root logger's level. This keeps the "user" protected.

--- a/calratio_training_data/sx_utils.py
+++ b/calratio_training_data/sx_utils.py
@@ -47,7 +47,7 @@ def build_sx_spec(
 
     # Build the ServiceX spec
     spec = ServiceXSpec(
-        Sample=[
+        Sample=[  # type: ignore
             Sample(
                 Name="MySample",
                 Dataset=dataset,

--- a/calratio_training_data/training_query.py
+++ b/calratio_training_data/training_query.py
@@ -1,9 +1,10 @@
 import logging
 from dataclasses import dataclass
 from math import sqrt
-from typing import Dict
+from typing import Any, Dict, Generator
 
 import awkward as ak
+import uproot
 import numpy as np
 import servicex_local as sx_local
 import vector
@@ -20,7 +21,6 @@ from func_adl_servicex_xaodr25.xAOD.truthparticle_v1 import TruthParticle_v1
 from func_adl_servicex_xaodr25.xAOD.vertex_v1 import Vertex_v1
 from func_adl_servicex_xaodr25.xAOD.vxtype import VxType
 from servicex import deliver
-from servicex_analysis_utils import to_awk
 
 from calratio_training_data.constants import (
     JET_MSEG_DELTA_PHI,
@@ -75,9 +75,12 @@ class TopLevelEvent:
     bsm_particles: FADLStream[TruthParticle_v1]
 
 
+logging.warning("Jet Cleanup Is Turned Off - TURN BACK ON")
+
+
 def good_training_jet(jet: Jet_v1) -> bool:
     """Check that the jet is suitable for training"""
-    return jet.pt() / 1000.0 > 40.0 and abs(jet.eta()) < 2.5 and jet_clean_llp(jet)
+    return jet.pt() / 1000.0 > 40.0 and abs(jet.eta()) < 2.5  # and jet_clean_llp(jet)
 
 
 def build_preselection():
@@ -531,22 +534,23 @@ def fetch_training_data_to_file(ds_name: str, config: RunConfig):
     result_list = fetch_training_data(ds_name, config)
 
     # Finally, write it out into a training file.
-    ak.to_parquet(
-        result_list, config.output_path, compression="ZSTD", compression_level=-7
-    )
+    for r in result_list:
+        ak.to_parquet(r, config.output_path, compression="ZSTD", compression_level=-7)
 
 
 def fetch_training_data(ds_name, config: RunConfig):
     raw_data = fetch_raw_training_data(ds_name, config)
-    result_list = convert_to_training_data(raw_data, mc=config.mc)
-    return result_list
+    for ar in raw_data:
+        yield convert_to_training_data(ar, mc=config.mc)
+    # result_list = convert_to_training_data(raw_data, mc=config.mc)
+    # return result_list
 
 
 def run_query(
     ds_name: str,
     query: ObjectStream,
     config: RunConfig = RunConfig(ignore_cache=False, run_locally=False),
-) -> Dict[str, ak.Array]:
+) -> Generator[Dict[str, ak.Array], Any, None]:
     # Build the ServiceX spec and run it.
     from .sx_utils import build_sx_spec
 
@@ -563,6 +567,15 @@ def run_query(
         sx_result = deliver(
             spec, servicex_name=backend_name, ignore_local_cache=config.ignore_cache
         )
-    result_list = to_awk(sx_result)["MySample"]
-    logging.info(f"Received {len(result_list)} entries.")
-    return result_list
+
+    # Work one file at a time to return the results.
+    if sx_result is None:
+        raise ValueError("No result from ServiceX!")
+
+    entries = 0
+    for file in sx_result["MySample"]:
+        f_data = uproot.open(file)["atlas_xaod_tree"].arrays()  # type: ignore
+        entries += len(f_data)
+        yield f_data  # type: ignore
+
+    logging.info(f"Received {entries} entries.")


### PR DESCRIPTION
Currently we write out the full dataset as a single array in a single data file. This does not work when the samples get large enough - we don't have that kind of memory. This PR adds chunking.

- Fix type warnings and logging configuration errors.
- Implement writing of multiple segmented files based on memory constraints.
- Adjust logging messages for clarity and to indicate ignored features.
- Correct spelling errors throughout the code.
- Files are handed around as an iterable, which will affect others using this (like the notebooks).

NOTE: Remove jet-cleaning check and also timing because they aren't in the current LLP1 datasets on the GRID. Warnings added which are super annoying to remind us to put it back in.

Fix #115