### PR TITLE
Add n-files option

### DIFF
--- a/calratio_training_data/fetch.py
+++ b/calratio_training_data/fetch.py
@@ -67,6 +67,11 @@ def main(
         "--sx-backend",
         help="ServiceX backend Name. Default is to use what is in your `servicex.yaml` file.",
     ),
+    n_files: Optional[int] = typer.Option(
+        None,
+        "--n-files", "-n",
+        help="Number of files to process in the dataset. Default is to process all files.",
+    ),
 ):
     """
     Fetch training data for cal ratio.
@@ -84,6 +89,7 @@ def main(
         mc=mc,
         do_rotation=do_rotation,
         sx_backend=sx_backend,
+        n_files=n_files,
     )
     fetch_training_data_to_file(dataset, run_config)
 

--- a/calratio_training_data/sx_utils.py
+++ b/calratio_training_data/sx_utils.py
@@ -22,6 +22,7 @@ def build_sx_spec(
     ds_name: str,
     prefer_local: bool = False,
     backend_name: Optional[str] = None,
+    n_files: Optional[int] = None,
 ):
     """Build a ServiceX spec from the given query and dataset."""
 
@@ -53,6 +54,7 @@ def build_sx_spec(
                 Dataset=dataset,
                 Query=query,
                 Codegen=codegen_name,
+                NFiles=n_files,
             ),
         ],
     )

--- a/calratio_training_data/training_query.py
+++ b/calratio_training_data/training_query.py
@@ -57,6 +57,7 @@ class RunConfig:
     mc: bool = False
     do_rotation: bool = True
     sx_backend: Optional[str] = None
+    n_files: Optional[int] = None
 
 
 @dataclass
@@ -604,7 +605,11 @@ def run_query(
     from .sx_utils import build_sx_spec
 
     spec, backend_name, adaptor = build_sx_spec(
-        query, ds_name, config.run_locally, config.sx_backend
+        query,
+        ds_name,
+        prefer_local=config.run_locally,
+        backend_name=config.sx_backend,
+        n_files=config.n_files
     )
     if config.run_locally or backend_name == "local-backend":
         sx_result = sx_local.deliver(


### PR DESCRIPTION
- Introduce an `--n-files` (`-n`) option to specify the number of files to process in the dataset, defaulting to all files.
- Update the `build_sx_spec` function to accept the new `n_files` parameter.
- Modify the `RunConfig` class to include the `n_files` attribute.

Fixes #118