### PR TITLE
Fixed issue with sorting cluster/tracks by pT

### DIFF
--- a/calratio_training_data/processing.py
+++ b/calratio_training_data/processing.py
@@ -13,7 +13,7 @@ def relative_angle(jets: ak.Array, objects: ak.Array):
 def sort_by_pt(data: ak.Array) -> ak.Array:
     # Sorts the data in place by pT
     new_data_index = ak.argsort(data.pt, axis=1, ascending=False)
-    data[new_data_index]
+    return data[new_data_index]
 
 
 def do_rotations(data: ak.Array, datatype, jets: Optional[ak.Array] = None):
@@ -21,8 +21,6 @@ def do_rotations(data: ak.Array, datatype, jets: Optional[ak.Array] = None):
     Do rotations on clusters (tracks, msegs). Done to get the highest cluster (track, mseg) by pT
     is at the center. Ensures NN learns from a standardized set of jets.
     Assumed data is flattened to per jet (instead of per event).
-
-    WARNING: Data is rotated in place!!!
 
     Args:
         data (ak.Array): Data to be rotated, contained either clusters, tracks, or msegs
@@ -36,7 +34,7 @@ def do_rotations(data: ak.Array, datatype, jets: Optional[ak.Array] = None):
 
     if datatype == "cluster" or datatype == "track":
         # Sort the data if its a cluster or a track
-        sort_by_pt(data)
+        data = sort_by_pt(data)
         if datatype == "cluster":
             relative_angle(ak.firsts(data), data)
         if datatype == "track":
@@ -64,3 +62,4 @@ def do_rotations(data: ak.Array, datatype, jets: Optional[ak.Array] = None):
         data["phiPos"] = mseg_dphi_pos
         mseg_dphi_dir = rectify(np, data.phiDir - jets.phi)
         data["phiDir"] = mseg_dphi_dir
+    return data

--- a/calratio_training_data/training_query.py
+++ b/calratio_training_data/training_query.py
@@ -536,11 +536,13 @@ def convert_to_training_data(
 
     # Doing rotations on tracks, clusters, msegs
     if rotation:
-        do_rotations(
+        per_jet_training_data_dict["tracks"] = do_rotations(
             per_jet_training_data_dict["tracks"], "track", ak.flatten(jets, axis=1)
         )
-        do_rotations(per_jet_training_data_dict["clusters"], "cluster")
-        do_rotations(
+        per_jet_training_data_dict["clusters"] = do_rotations(
+            per_jet_training_data_dict["clusters"], "cluster"
+        )
+        per_jet_training_data_dict["msegs"] = do_rotations(
             per_jet_training_data_dict["msegs"], "mseg", ak.flatten(jets, axis=1)
         )
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -9,10 +9,10 @@ def test_do_rotations_clusters():
         [
             [
                 {"pt": 10.0, "eta": 0.5, "phi": 1.0},
-                {"pt": 5.0, "eta": 2.3, "phi": 2.3},
+                {"pt": 15.0, "eta": 2.3, "phi": 2.3},
             ],
             [
-                {"pt": 20.0, "eta": -2.0, "phi": 2.1},
+                {"pt": 2.0, "eta": -2.0, "phi": 2.1},
                 {"pt": 4.0, "eta": 0.3, "phi": 6.1},
             ],
         ],
@@ -37,17 +37,22 @@ def test_do_rotations_clusters():
     correct_array = ak.Array(
         [
             [
-                {"pt": 10.0, "eta": 0, "phi": 0},
-                {"pt": 5.0, "eta": 1.8, "phi": 1.3},
+                {"pt": 15.0, "eta": 0, "phi": 0},
+                {"pt": 10.0, "eta": 1.8, "phi": 1.3},
             ],
             [
-                {"pt": 20.0, "eta": 0, "phi": 0},
-                {"pt": 4.0, "eta": 2.3, "phi": 2.28},
+                {"pt": 4.0, "eta": 0, "phi": 0},
+                {"pt": 2.0, "eta": 2.3, "phi": 2.28},
             ],
         ],
         with_name="Momentum3D",
     )
-    do_rotations(cluster_array, "cluster", jet_array)
+    cluster_array = do_rotations(cluster_array, "cluster", jet_array)
+
+    # Asserting the pT is correctly sorted
+    assert ak.all(
+        cluster_array.pt == ak.sort(cluster_array.pt, axis=-1, ascending=False)
+    )
 
     # Using to_list to avoid problems with -0 ≠ 0 comparison
     assert (
@@ -59,12 +64,12 @@ def test_do_rotations_tracks():
     track_array = ak.Array(
         [
             [
-                {"eta": 0.9, "phi": 8.9, "pt": 10.0},
-                {"eta": 3.1, "phi": -1.3, "pt": 5.0},
+                {"eta": 0.9, "phi": 8.9, "pt": 5.0},
+                {"eta": 3.1, "phi": -1.3, "pt": 15.0},
             ],
             [
-                {"eta": -2.4, "phi": 1.43, "pt": 20.0},
-                {"eta": 1.42, "phi": 4.23, "pt": 4.0},
+                {"eta": -2.4, "phi": 1.43, "pt": 2.0},
+                {"eta": 1.42, "phi": 4.23, "pt": 14.0},
             ],
         ],
         with_name="Momentum3D",
@@ -86,21 +91,24 @@ def test_do_rotations_tracks():
         with_name="Momentum3D",
     )
 
-    do_rotations(track_array, "track", jet_array)
+    track_array = do_rotations(track_array, "track", jet_array)
 
     correct_array = ak.Array(
         [
             [
-                {"pt": 10.0, "eta": 0.4, "phi": 1.42},
-                {"pt": 5, "eta": 2.6, "phi": -2.5},
+                {"pt": 15.0, "eta": 2.6, "phi": 2.5},
+                {"pt": 5, "eta": 0.4, "phi": -1.42},
             ],
             [
-                {"pt": 20.0, "eta": 1.3, "phi": 1.37},
-                {"pt": 4.0, "eta": -2.52, "phi": -1.43},
+                {"pt": 14, "eta": 2.52, "phi": 1.43},
+                {"pt": 2, "eta": -1.3, "phi": -1.37},
             ],
         ],
         with_name="Momentum3D",
     )
+
+    # Asserting the pT is correctly sorted
+    assert ak.all(track_array.pt == ak.sort(track_array.pt, axis=-1, ascending=False))
 
     assert ak.array_equal(
         ak.round(track_array, 2), correct_array
@@ -137,7 +145,7 @@ def test_do_rotations_msegs():
         with_name="Momentum3D",
     )
 
-    do_rotations(mseg_array, "mseg", jet_array)
+    mseg_array = do_rotations(mseg_array, "mseg", jet_array)
 
     correct_array = ak.Array(
         [


### PR DESCRIPTION
Sorting by pT in processing.py was not actually sorting anything by pT. Now it is correctly doing that, and the test was improved to check if the pT was, in fact, sorted.

Fixes #143 