### PR TITLE
Add dataset parsing utility for ServiceX sample naming

### DIFF
--- a/calratio_training_data/sx_utils.py
+++ b/calratio_training_data/sx_utils.py
@@ -17,6 +17,35 @@ class SXLocationOptions(Enum):
     anyLocation = "anyLocation"
 
 
+def extract_run_number_and_name(ds_name: str) -> Tuple[Optional[str], str]:
+    """Extract the run number and dataset name from an ATLAS DID string.
+
+    Args:
+        ds_name (str): The dataset identifier to parse.
+
+    Returns:
+        Tuple[Optional[str], str]: A tuple containing the run number (if found)
+        and the dataset name. When parsing fails, the dataset name is the first
+        30 characters of ``ds_name`` and the run number is ``None``.
+    """
+
+    # Strip whitespace so we can reliably parse the DID string.
+    did = ds_name.strip()
+
+    # Match an optional scope (``scope:``), followed by the project and the run
+    # number. The dataset name is the string immediately following the run.
+    did_pattern = re.compile(r"(?:[^:]+:)?[^.]+\.(?P<run>\d+)\.(?P<name>[^.]+)")
+    match = did_pattern.search(did)
+    if not match:
+        truncated_name = did[:30]
+        return None, truncated_name
+
+    run_number = match.group("run")
+    dataset_name = match.group("name")
+
+    return run_number, dataset_name
+
+
 def build_sx_spec(
     query,
     ds_name: str,
@@ -47,10 +76,16 @@ def build_sx_spec(
         codegen_name = "atlasr25"
 
     # Build the ServiceX spec
+    run_number, dataset_name = extract_run_number_and_name(ds_name)
+    if run_number:
+        sample_name = f"calratio_{run_number}_{dataset_name}"
+    else:
+        sample_name = f"calratio_{dataset_name}"
+
     spec = ServiceXSpec(
         Sample=[  # type: ignore
             Sample(
-                Name="MySample",
+                Name=sample_name,
                 Dataset=dataset,
                 Query=query,
                 Codegen=codegen_name,


### PR DESCRIPTION
## Summary
- add a helper to extract the run number and dataset name from ATLAS dataset identifiers
- use the parsed identifiers to build ServiceX sample names in the calratio format
- expand the ServiceX utility tests to cover the parser and naming fallback behaviour

## Testing
- black calratio_training_data/sx_utils.py tests/test_sx_utils.py
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dd046e31c83209292cef204a3a08e)