### PR TITLE
Removed hardcoded min/max jet pT, added missing cut for high pT jet

### DIFF
--- a/calratio_training_data/training_query.py
+++ b/calratio_training_data/training_query.py
@@ -33,6 +33,8 @@ from calratio_training_data.constants import (
     LLP_Lxy_min,
     LLP_Lz_max,
     LLP_Lz_min,
+    min_jet_pt,
+    max_jet_pt,
 )
 
 from .cpp_xaod_utils import (
@@ -86,7 +88,9 @@ logging.warning("Jet Cleanup Is Turned Off - TURN BACK ON")
 
 def good_training_jet(jet: Jet_v1) -> bool:
     """Check that the jet is suitable for training"""
-    return jet.pt() / 1000.0 > 40.0 and abs(jet.eta()) < 2.5  # and jet_clean_llp(jet)
+    return (jet.pt() / 1000.0 > min_jet_pt and jet.pt() / 1000.0 < max_jet_pt) and abs(
+        jet.eta()
+    ) < 2.5  # and jet_clean_llp(jet)
 
 
 def build_preselection():


### PR DESCRIPTION
Replaced the 40/500 GeV cuts in the code with the min/max jet pT variables that are defined in constants.py. The `good_training_jet` function was also missing a cut for jets over 500GeV - not sure if this was intentional? Added it back in if it was missing on accident. 

Fixes #132 