### PR TITLE
Added ability for eventfilter input using regex

### DIFF
--- a/calratio_training_data/combining.py
+++ b/calratio_training_data/combining.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Optional, List
 from pathlib import Path
 import awkward as ak
+import re
 
 
 # Data class for combine configuration options
@@ -12,7 +13,23 @@ class CombineConfig:
 
 
 def combine_training_data(input_files: List[Path], config: CombineConfig):
-    arrays = [ak.from_parquet(f) for f in input_files]
+
+    # Creating a filter for the events
+    if config.event_filter is not None:
+        # Apply the filter to the events
+        arrays = []
+
+        # using regex to get the mask
+        m = re.search(r"% (\d+)\s*==\s*(\d+)", config.event_filter)
+
+        # looping through the input files and applying the filter to them
+        for f in input_files:
+            arr = ak.from_parquet(f)
+            mask = arr["eventNumber"] % int(m.group(1)) == int(m.group(2))
+            filtered = arr[mask]
+            arrays.append(filtered)
+    else:
+        arrays = [ak.from_parquet(f) for f in input_files]
     combined = ak.concatenate(arrays, axis=0)
     ak.to_parquet(combined, config.output_path)
     return combined


### PR DESCRIPTION
Able to filter by event number now, input should be a string that looks like "n % x = y". value for n is disregarded. 

Pandas dataframes had a .query function that allowed for a string to be passed, which was useful for user input. This still allows the user to input a mod expression, but we just have to parse it as integers to create a mask for awkward.  