### PR TITLE
Lazy-load training_query to speed CLI startup

### DIFF
--- a/calratio_training_data/__init__.py
+++ b/calratio_training_data/__init__.py
@@ -1,7 +1,34 @@
-from .training_query import (  # noqa
-    fetch_training_data,
-    fetch_training_data_to_file,
-    build_preselection,
-    run_query,
-    RunConfig,
-)
+"""Public package API with lazy imports.
+
+Keeping imports lazy here avoids importing the heavy ServiceX/query stack during CLI
+startup (for example ``calratio_training_data --help``), while preserving the
+existing public symbols.
+"""
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+__all__ = [
+    "RunConfig",
+    "build_preselection",
+    "fetch_training_data",
+    "fetch_training_data_to_file",
+    "run_query",
+]
+
+if TYPE_CHECKING:
+    from .training_query import (
+        RunConfig,
+        build_preselection,
+        fetch_training_data,
+        fetch_training_data_to_file,
+        run_query,
+    )
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily expose selected symbols from ``training_query`` on first access."""
+    if name in __all__:
+        training_query_module = import_module(".training_query", __name__)
+        return getattr(training_query_module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -1,0 +1,35 @@
+import subprocess
+import sys
+
+
+def test_package_init_is_lazy() -> None:
+    """Importing the package should not import the heavy training query module."""
+    command = (
+        "import calratio_training_data, sys; "
+        "print('calratio_training_data.training_query' in sys.modules)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", command],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == "False"
+
+
+def test_package_init_lazy_symbol_access() -> None:
+    """Accessing a public symbol should trigger loading training_query lazily."""
+    command = (
+        "import calratio_training_data, sys; "
+        "_ = calratio_training_data.RunConfig; "
+        "print('calratio_training_data.training_query' in sys.modules)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", command],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == "True"


### PR DESCRIPTION
### Motivation
- CLI startup and `--help` were slow because importing the package pulled in the heavy ServiceX/FuncADL stack from `training_query` on package import. 
- Defer importing expensive modules until the actual command/runtime need to avoid paying the import cost for help/error paths. 

### Description
- Replaced eager runtime imports in `calratio_training_data/__init__.py` with a lazy export layer that exposes selected symbols (`RunConfig`, `build_preselection`, `fetch_training_data`, `fetch_training_data_to_file`, `run_query`) via `__getattr__` and `importlib.import_module` on first access. 
- Added `TYPE_CHECKING`-only imports to preserve type hints for tooling while avoiding runtime cost. 
- Added `tests/test___init__.py` to assert that importing the package does not load `training_query` and that accessing a public symbol triggers the deferred import. 

### Testing
- Ran the test suite with `python -m pytest` and all tests passed (30 passed). 
- Formatted the changed files with `python -m black` successfully. 
- `flake8` is not available in the environment (error: `No module named flake8`). 
- Verified that CLI help continues to work with `python -m calratio_training_data.fetch --help`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d3b7036448320822204641af62a9a)