### PR TITLE
Added support for a descriptive label to differentiate datasets

### DIFF
--- a/calratio_training_data/fetch.py
+++ b/calratio_training_data/fetch.py
@@ -45,6 +45,10 @@ def fetch_command(
         ..., help="Type of data to fetch (signal, qcd, data, bib)"
     ),
     dataset: str = typer.Argument(..., help="The data source"),
+    desc_label: str = typer.Argument(
+        ...,
+        help='Descriptive label used for labeling datasets. Ex. "HSS, JZ2, data24"',
+    ),
     verbosity: int = typer.Option(
         0,
         "--verbose",
@@ -103,6 +107,7 @@ def fetch_command(
         sx_backend=sx_backend,
         n_files=n_files,
         datatype=data_type,
+        desc_label=desc_label,
     )
     fetch_training_data_to_file(dataset, run_config)
 

--- a/calratio_training_data/label_utils.py
+++ b/calratio_training_data/label_utils.py
@@ -1,0 +1,17 @@
+import re
+
+
+def extract_param_block(s: str) -> str | None:
+    """
+    Extracts parameter information about a given dataset
+    Should output a string like "mH600_mS40_ct80" or similar
+    """
+    # Only consider part before ".deriv"
+    prefix = s.split(".deriv")[0]
+
+    # Pattern: lowercase-led parameters chained with underscores
+    pattern = r"(?:[a-z][a-zA-Z]*[0-9]+(?:_[a-z][a-zA-Z]*[0-9]+)+)"
+
+    matches = re.findall(pattern, prefix)
+
+    return matches[-1] if matches else None

--- a/calratio_training_data/training_query.py
+++ b/calratio_training_data/training_query.py
@@ -48,6 +48,7 @@ from .cpp_xaod_utils import (
 )
 
 from calratio_training_data.fetch import DataType
+from calratio_training_data.label_utils import extract_param_block
 
 
 vector.register_awkward()
@@ -63,6 +64,7 @@ class RunConfig:
     sx_backend: Optional[str] = None
     n_files: Optional[int] = None
     datatype: DataType = DataType.SIGNAL
+    desc_label: str = ""
 
 
 @dataclass
@@ -352,7 +354,11 @@ def fetch_raw_training_data(
 
 
 def convert_to_training_data(
-    data: Dict[str, ak.Array], datatype: DataType, rotation: bool = True
+    data: Dict[str, ak.Array],
+    datatype: DataType,
+    ds_name: str,
+    rotation: bool = True,
+    desc_label="",
 ) -> ak.Array:
     """
     Convert raw data dictionary to training data format.
@@ -676,6 +682,17 @@ def convert_to_training_data(
         [label_value] * len(per_jet_training_data_dict["pt"])
     )
 
+    # Adding descriptive label
+    if datatype == DataType.SIGNAL:
+        full_label = desc_label + "_" + extract_param_block(ds_name)
+        per_jet_training_data_dict["desc_label"] = ak.Array(
+            [full_label] * len(per_jet_training_data_dict["pt"])
+        )
+    else:
+        per_jet_training_data_dict["desc_label"] = ak.Array(
+            [desc_label] * len(per_jet_training_data_dict["pt"])
+        )
+
     # Finally, build the data we will write out!
     training_data = ak.zip(
         per_jet_training_data_dict, with_name="Momentum3D", depth_limit=1
@@ -735,7 +752,11 @@ def fetch_training_data(ds_name, config: RunConfig):
     raw_data = fetch_raw_training_data(ds_name, config)
     for ar in raw_data:
         yield convert_to_training_data(
-            ar, datatype=config.datatype, rotation=config.rotation
+            ar,
+            datatype=config.datatype,
+            ds_name=ds_name,
+            rotation=config.rotation,
+            desc_label=config.desc_label,
         )
 
 

--- a/tests/test_training_query.py
+++ b/tests/test_training_query.py
@@ -67,8 +67,12 @@ def test_convert_to_training_data_mc_no_rotation():
     # Convert to awkward Record to support both dict and attribute access
     raw_data = ak.Array([raw_data_dict])[0]
 
+    ds_name = "ds_test_mH23_ms13"
+
     # Call the function
-    result = convert_to_training_data(raw_data, DataType.SIGNAL, rotation=False)
+    result = convert_to_training_data(
+        raw_data, DataType.SIGNAL, ds_name, rotation=False
+    )
 
     # Basic checks - ensure the function runs without error and returns an array
     assert result is not None
@@ -151,8 +155,12 @@ def test_convert_to_training_no_llps():
     # Convert to awkward Record to support both dict and attribute access
     raw_data = ak.Array([raw_data_dict])[0]
 
+    ds_name = "ds_test_mH23_ms13"
+
     # Call the function
-    result = convert_to_training_data(raw_data, DataType.SIGNAL, rotation=False)
+    result = convert_to_training_data(
+        raw_data, DataType.SIGNAL, ds_name, rotation=False
+    )
 
     # Basic checks - ensure the function runs without error and returns an array
     assert result is not None
@@ -221,8 +229,10 @@ def test_convert_to_training_data_bib_select_min_emf():
     # Convert to awkward Record to support both dict and attribute access
     raw_data = ak.Array([raw_data_dict])[0]
 
-    # Call the function with BIB datatype
-    result = convert_to_training_data(raw_data, DataType.BIB, rotation=False)
+    ds_name = "data24_dataset"
+
+    # Call the function
+    result = convert_to_training_data(raw_data, DataType.BIB, ds_name, rotation=False)
 
     # Verify the function runs and returns an array
     assert result is not None
@@ -356,8 +366,10 @@ def test_convert_to_training_data_bib_multiple_events():
     # Convert to awkward Record
     raw_data = ak.Array([raw_data_dict])[0]
 
+    ds_name = "data24_dataset"
+
     # Call the function with BIB datatype
-    result = convert_to_training_data(raw_data, DataType.BIB, rotation=False)
+    result = convert_to_training_data(raw_data, DataType.BIB, ds_name, rotation=False)
 
     # Verify the function runs and returns an array
     assert result is not None
@@ -443,8 +455,12 @@ def test_convert_to_training_no_near_llps():
     # Convert to awkward Record to support both dict and attribute access
     raw_data = ak.Array([raw_data_dict])[0]
 
+    ds_name = "ds_test_mH23_ms13"
+
     # Call the function
-    result = convert_to_training_data(raw_data, DataType.SIGNAL, rotation=False)
+    result = convert_to_training_data(
+        raw_data, DataType.SIGNAL, ds_name, rotation=False
+    )
 
     # Basic checks - ensure the function runs without error and returns an array
     assert result is not None


### PR DESCRIPTION
Adds a required argument when processing files to include a descriptive label for the dataset. For BIB and QCD, this would be something like "data24" or "mc23_jz2". For signal, the input should just be related to the type of signal (charming alp, HSS, etc.). Then the code then picks out any mass/lifetime tags in the dataset name and appends it to the inputted description as well. This is added as an extra column to the overall processed dataset to be used in the future for benchmarking NN training on different kinds of signal/masses/lifetimes.

Fixes #171 