### PR TITLE
Restricted to not use latest SXLocal version because it breaks current code.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "vector",
     "pyarrow",
     "uproot",
-    "ServiceX-Local",
+    "ServiceX-Local<1.0.0",
     "func_adl_servicex_xaodr25",
     "servicex-analysis-utils",
     "jinja2",


### PR DESCRIPTION
Limits to use under 1.0.0 for SXLocal.